### PR TITLE
remove unneeded dependancies to reduce errors from calling library() by new users

### DIFF
--- a/scripts/01_load_data.R
+++ b/scripts/01_load_data.R
@@ -10,7 +10,7 @@ Options:
 --output_path=<output_path> Path and filename where to designate the file and what to call it.
 " -> doc
 
-library(tidyverse)
+library(readr)
 library(janitor)
 library(docopt)
 

--- a/scripts/02_cleaning.R
+++ b/scripts/02_cleaning.R
@@ -8,7 +8,7 @@ that needs to happen before exploratory data analysis or modeling.
 Usage: 02_cleaning.R --file_path=<file_path> --output_path=<output_path>
 " -> doc
 
-library(tidyverse)
+library(readr)
 library(docopt)
 
 opt <- docopt(doc)

--- a/scripts/03_eda_tbl.R
+++ b/scripts/03_eda_tbl.R
@@ -8,7 +8,7 @@ Usage: 03_eda_tbl.R --input_unprocessed=<input_unprocessed> --input_processed=<i
 
 " -> doc
 
-library(tidyverse)
+library(readr)
 library(docopt)
 
 opt <- docopt(doc)

--- a/scripts/04_eda_viz.R
+++ b/scripts/04_eda_viz.R
@@ -7,9 +7,8 @@ the data set. The visualizations and tables will be saved as files.
 Usage: 04_eda_viz.R --input_unprocessed=<input_unprocessed> --input_processed=<input_processed> --output_fig1=<output_fig1> --output_fig2=<output_fig2>
 " -> doc
 
-library(tidyverse)
+library(readr)
 library(docopt)
-library(GGally)
 
 # Parse command line options
 opt <- docopt(doc)
@@ -24,7 +23,7 @@ us_selected <- read_csv(processed_data_path)
 # Figure 1: Pair plot of all variables (from processed data)
 covidanxietytrends::create_pairs_plot(us_selected, opt$output_fig1, width = 16, height = 12)
 
-ggsave(opt$output_fig1, width = 15)
+ggplot2::ggsave(opt$output_fig1, width = 15)
 
 
 # Figure 2: Time series plot on anxiety search trend across all COVID-19 dates
@@ -32,5 +31,5 @@ options(repr.plot.width = 14, repr.plot.height = 9)
 
 anxiety_time_plot <- covidanxietytrends::plot_anxiety_time_series(us_covid, opt$output_fig2)
 
-ggsave(opt$output_fig2, width = 10)
+ggplot2::ggsave(opt$output_fig2, width = 10)
 

--- a/scripts/05_feature_selection.R
+++ b/scripts/05_feature_selection.R
@@ -17,8 +17,8 @@ library(covidanxietytrends)
 
 set.seed(310)
 
-library(tidyverse)
-library(tidymodels)
+library(readr)
+library(dplyr)
 library(docopt)
 library(leaps)
 

--- a/scripts/06_model_results.R
+++ b/scripts/06_model_results.R
@@ -13,7 +13,7 @@ Options:
 
 set.seed(310)
 library(docopt)
-library(tidyverse)
+library(readr)
 
 opt <- docopt(doc)
 


### PR DESCRIPTION
remove unneeded dependancies to reduce errors from calling library() by new users